### PR TITLE
deps: bump quiche-zig to quiche 0.29.2 (GHSA-mh64-ph39-mrc9)

### DIFF
--- a/.github/workflows/interop-gossipsub.yml
+++ b/.github/workflows/interop-gossipsub.yml
@@ -1,0 +1,106 @@
+name: Gossipsub interop
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  ZIG_VERSION: 0.16.0
+
+# The gossipsub interop scenarios launch real OS processes over loopback QUIC
+# (no Docker/Redis/external harness), so they run on a single ubuntu-latest host
+# and exit non-zero on failure. The scripts build with GOPROXY=off / cargo
+# --offline, so we seed the module/crate caches online first.
+jobs:
+  gossipsub-interop:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Zig
+        id: cache
+        uses: actions/cache@v5
+        with:
+          path: ~/zig
+          key: ${{ runner.os }}-zig-${{ env.ZIG_VERSION }}
+
+      - name: Install Zig
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          wget https://ziglang.org/download/${{ env.ZIG_VERSION }}/zig-x86_64-linux-${{ env.ZIG_VERSION }}.tar.xz
+          tar -xf zig-x86_64-linux-${{ env.ZIG_VERSION }}.tar.xz
+          mv zig-x86_64-linux-${{ env.ZIG_VERSION }} ~/zig
+
+      - name: Add Zig to PATH
+        run: echo "${HOME}/zig" >> $GITHUB_PATH
+
+      - name: Cache Zig build artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            zig-cache
+            ~/.cache/zig
+          key: ${{ runner.os }}-zig-build-${{ hashFiles('**/*.zig') }}
+          restore-keys: |
+            ${{ runner.os }}-zig-build-
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: interop/gossipsub/go-peer/go.sum
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust (cargo + rust-peer target)
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            interop/gossipsub/rust-peer/target
+          key: ${{ runner.os }}-gspeer-rust-${{ hashFiles('interop/gossipsub/rust-peer/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gspeer-rust-
+
+      # The build scripts run go/cargo offline; populate the caches online first.
+      - name: Seed go-peer modules
+        run: cd interop/gossipsub/go-peer && go mod download
+
+      - name: Seed rust-peer crates
+        run: cd interop/gossipsub/rust-peer && cargo fetch
+
+      - name: zig <-> zig (smoke)
+        run: bash interop/gossipsub/run-zig-zig.sh
+
+      - name: zig <-> go
+        run: bash interop/gossipsub/run-zig-go.sh
+
+      - name: zig <-> rust
+        run: bash interop/gossipsub/run-zig-rust.sh
+
+      - name: cross-impl peer-exchange (go <-> zig)
+        run: bash interop/gossipsub/run-px-crossimpl.sh
+
+      - name: mixed-impl mesh
+        run: bash interop/gossipsub/run-mixed-mesh.sh
+
+      - name: anonymous mixed mesh
+        run: bash interop/gossipsub/run-anonymous-mixed.sh
+
+      - name: version fallback (meshsub 1.1 <-> 1.2)
+        run: bash interop/gossipsub/run-version-fallback.sh
+
+      - name: large-mesh gossip
+        run: bash interop/gossipsub/run-gossip-large.sh
+
+      - name: churn
+        run: bash interop/gossipsub/run-churn.sh

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -30,8 +30,8 @@
             .hash = "secp256k1-0.0.3-vtxi56DlAACjVafQhd5hn8ClU4o2GdG6X4zUP75NsNCc",
         },
         .quiche_zig = .{
-            .url = "git+https://github.com/chainsafe/quiche-zig#2e0b489b3c9900f658ca97b766b802003525cdb0",
-            .hash = "quiche-0.1.0-rnTCo4cQAACPgyY1ZYEYw7Yw0JNl2jGqlVLz6pOmA06t",
+            .url = "git+https://github.com/GrapeBaBa/quiche-zig#fb1fef3a8cba68327014b8fecf324bd9b7e97cb2",
+            .hash = "quiche-0.1.0-rnTCo5IdAACTLOhOYW-uvl6zoeN0YvNDZS0l1TZaWBC5",
         },
         .zio = .{
             .url = "git+https://github.com/lalinsky/zio#ad85c354d06fc6f7904ce9bbe3dff9498595ea25",

--- a/src/quic/connection/actor.zig
+++ b/src/quic/connection/actor.zig
@@ -1370,14 +1370,12 @@ pub const ConnectionActor = struct {
 
     fn drainRetiredSourceCids(self: *ConnectionActor) usize {
         const conn = self.conn orelse return 0;
-        // Drain quiche's retired-SCID queue WITHOUT reading the out-pointer:
-        // `quiche_conn_retired_scid_next` has the same use-after-free as the
-        // connection-id iterator (ConnectionId dropped before the call returns).
-        // The retired cid lingers in our registry/route table until teardown:
-        // dead weight, not a hazard — quiche drops stray packets for it.
-        var cid_ptr: [*c]const u8 = null;
-        var cid_len: usize = 0;
-        while (quiche.quiche_conn_retired_scid_next(conn, &cid_ptr, &cid_len)) {}
+        // Drain quiche's retired-SCID queue: the iterator pops every retired CID
+        // into its own storage, so creating then freeing it clears the queue. We
+        // don't read the CIDs — they linger in our registry/route table until
+        // teardown: dead weight, not a hazard (quiche drops stray packets for it).
+        const iter = quiche.quiche_conn_retired_scid_iter(conn) orelse return 0;
+        quiche.quiche_connection_id_iter_free(iter);
         return 0;
     }
 


### PR DESCRIPTION
Bumps `quiche-zig` to quiche **0.29.2** (security fix) + adapts to the one 0.28→0.29 C-API change.

### Why
0.29.2 carries the fix for the quiche C-FFI use-after-free in `quiche_connection_id_iter_next` / `quiche_conn_retired_scid_next` (advisory GHSA-mh64-ph39-mrc9 / cloudflare/quiche `386ad632`). Our prior 0.28.0 pin is affected (we were safe in practice — `actor.zig` never read the freed pointers — but this moves us onto the patched release).

### Changes
- `build.zig.zon`: repin `quiche_zig` to the 0.29.2 quiche-zig.
- `src/quic/connection/actor.zig`: 0.29 **removed** the popping `quiche_conn_retired_scid_next` (the UAF one) in favor of the draining `quiche_conn_retired_scid_iter`. `drainRetiredSourceCids` now creates that iter (which drains the retired-SCID queue) + frees it — semantically identical to the old drain, no UAF.

### Verified
`zig build test` — **336/343 pass, 7 skipped** (macOS/kqueue).

### ⚠️ Temporary pin
Pins **`GrapeBaBa/quiche-zig@fb1fef3`** (fork) because the quiche-zig bump is still in review at **ChainSafe/quiche-zig#1**. **Repin to the upstream merged commit before merging.**

_Interop CI to follow on this branch._
